### PR TITLE
load all mongo results before reducing them

### DIFF
--- a/rframe/interfaces/mongo.py
+++ b/rframe/interfaces/mongo.py
@@ -198,25 +198,15 @@ class MongoAggregation(BaseDataQuery):
         # docs = list(self.collection.aggregate(pipeline, allowDiskUse=self.allow_disk_use))
         collected = 0
         limit = limit if limit is not None else float("inf")
-        docs = []
-        for doc in self.collection.aggregate(pipeline, allowDiskUse=allow_disk_use):
-            docs.append(doc)
-            if len(docs) >= self.docs_per_label:
-                docs = self.index.reduce(docs, self.labels)
-                for doc in docs:
-                    yield from_mongo(doc)
-                    collected += 1
-                    if collected >= limit:
-                        return
-                docs = []
 
-        if len(docs) and collected < limit:
-            docs = self.index.reduce(docs, self.labels)
-            for doc in docs:
-                yield from_mongo(doc)
-                collected += 1
-                if collected >= limit:
-                    return
+        docs = list(self.collection.aggregate(pipeline, allowDiskUse=allow_disk_use))
+        docs = self.index.reduce(docs, self.labels)
+
+        for doc in docs:
+            yield from_mongo(doc)
+            collected += 1
+            if collected >= limit:
+                return
 
     def unique(self, fields: Union[str, List[str]]):
         if isinstance(fields, str):

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -53,14 +53,14 @@ class TestJson(unittest.TestCase):
     #     InterpolatingSchema.test(self, db, docs)
 
     @given(IntegerIntervalSchema.list_strategy())
-    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow])
+    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much])
     def test_integer_interval(self, docs: IntegerIntervalSchema):
         db = DataAccessor(IntegerIntervalSchema, [])
 
         IntegerIntervalSchema.test(self, db, docs)
 
     @given(TimeIntervalSchema.list_strategy())
-    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow])
+    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much])
     def test_time_interval(self, docs: TimeIntervalSchema):
         db = DataAccessor(TimeIntervalSchema, [])
 

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -63,14 +63,14 @@ class TestMongo(unittest.TestCase):
         InterpolatingSchema.test(self, db, docs)
 
     @given(IntegerIntervalSchema.list_strategy())
-    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow])
+    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much])
     def test_integer_interval(self, docs: IntegerIntervalSchema):
         self.collection.delete_many({})
         db = DataAccessor(IntegerIntervalSchema, self.collection)
         IntegerIntervalSchema.test(self, db, docs)
 
     @given(TimeIntervalSchema.list_strategy())
-    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow])
+    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much])
     def test_time_interval(self, docs: TimeIntervalSchema):
         self.collection.delete_many({})
         db = DataAccessor(TimeIntervalSchema, self.collection)

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -40,13 +40,13 @@ class TestPandas(unittest.TestCase):
         InterpolatingSchema.test(self, db, docs)
 
     @given(IntegerIntervalSchema.list_strategy())
-    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow])
+    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much])
     def test_integer_interval(self, docs: IntegerIntervalSchema):
         db = DataAccessor(IntegerIntervalSchema, docs[0].dframe().head(0))
         IntegerIntervalSchema.test(self, db, docs)
 
     @given(TimeIntervalSchema.list_strategy())
-    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow])
+    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much])
     def test_time_interval(self, docs: TimeIntervalSchema):
         db = DataAccessor(TimeIntervalSchema, docs[0].dframe().head(0))
         TimeIntervalSchema.test(self, db, docs)

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -79,7 +79,7 @@ class TestRest(unittest.TestCase):
         InterpolatingSchema.test(self, db, docs)
 
     @given(IntegerIntervalSchema.list_strategy())
-    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow])
+    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much])
     def test_integer_interval(self, docs: IntegerIntervalSchema):
         self.tables[IntegerIntervalSchema].truncate()
         datasource = self.datasources[IntegerIntervalSchema]
@@ -87,7 +87,7 @@ class TestRest(unittest.TestCase):
         IntegerIntervalSchema.test(self, db, docs)
 
     @given(TimeIntervalSchema.list_strategy())
-    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow])
+    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much])
     def test_time_interval(self, docs: TimeIntervalSchema):
         self.tables[TimeIntervalSchema].truncate()
         datasource = self.datasources[TimeIntervalSchema]

--- a/tests/test_tinydb.py
+++ b/tests/test_tinydb.py
@@ -57,14 +57,14 @@ class TestTinyDB(unittest.TestCase):
         InterpolatingSchema.test(self, db, docs)
 
     @given(IntegerIntervalSchema.list_strategy())
-    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow])
+    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much])
     def test_integer_interval(self, docs: IntegerIntervalSchema):
         self.table.truncate()
         db = DataAccessor(IntegerIntervalSchema, self.table)
         IntegerIntervalSchema.test(self, db, docs)
 
     @given(TimeIntervalSchema.list_strategy())
-    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow])
+    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much])
     def test_time_interval(self, docs: TimeIntervalSchema):
         self.table.truncate()
         db = DataAccessor(TimeIntervalSchema, self.table)


### PR DESCRIPTION
This will avoid needing the values to be sorted for interpolation to succeed