### PR TITLE
Set timezone to UTC to avoid Daylight Saving Time

### DIFF
--- a/rframe/indexes/interpolating_index.py
+++ b/rframe/indexes/interpolating_index.py
@@ -1,3 +1,4 @@
+import pytz
 import datetime
 from typing import Callable, Union
 
@@ -73,11 +74,11 @@ class InterpolatingIndex(BaseIndex):
         if not docs or label is None:
             return docs
 
-        x = label.replace(tzinfo=None).timestamp() if isinstance(label, datetime.datetime) else label
+        x = label.replace(tzinfo=pytz.utc).timestamp() if isinstance(label, datetime.datetime) else label
         xs = [self.validate_label(d[self.name]) for d in docs]
         # just convert all datetimes to timestamps to avoid complexity
         # FIXME: maybe properly handle timezones instead
-        xs = [xi.replace(tzinfo=None).timestamp() if isinstance(xi, datetime.datetime) else xi for xi in xs]
+        xs = [xi.replace(tzinfo=pytz.utc).timestamp() if isinstance(xi, datetime.datetime) else xi for xi in xs]
         if len(docs) == 1:
             new_document = docs[0]
         else:


### PR DESCRIPTION
After setting `tzinfo=None`, the timestamp will only adapt to the timezone of the machine. But for some regions in the world, the Daylight Saving Time is applied. This will lead to a problem of shifted time of anchors.

For example, for `datetime.datetime(2023, 3, 11, 21, 6, 3)` and `datetime.datetime(2023, 3, 12, 3, 6, 3)` on a server in Chicago, the difference of their timestamps are 18000 seconds (5 hrs) but not 21600 seconds (6hrs).

```
>>> datetime.datetime(2023, 3, 11, 21, 6, 3).timestamp()
1678590363.0
>>> datetime.datetime(2023, 3, 12, 3, 6, 3).timestamp()
1678608363.0
>>> datetime.datetime(2023, 3, 12, 3, 6, 3).timestamp() - datetime.datetime(2023, 3, 11, 21, 6, 3).timestamp()
18000
```

This leads to a problem unless we fix the timezone to UTC.
